### PR TITLE
Implement `Clone` for `Rng`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,36 @@ impl Default for Rng {
     }
 }
 
+impl Clone for Rng {
+    /// Clones the generator by deterministically deriving a new generator based on the initial
+    /// seed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// // Seed two generators equally, and clone both of them.
+    /// let base1 = fastrand::Rng::new();
+    /// base1.seed(0x4d595df4d0f33173);
+    /// base1.bool(); // Use the generator once.
+    ///
+    /// let base2 = fastrand::Rng::new();
+    /// base2.seed(0x4d595df4d0f33173);
+    /// base2.bool(); // Use the generator once.
+    ///
+    /// let rng1 = base1.clone();
+    /// let rng2 = base2.clone();
+    ///
+    /// assert_eq!(rng1.u64(..), rng2.u64(..), "the cloned generators are identical");
+    /// ```
+    fn clone(&self) -> Rng {
+        let seed = self.gen_u64();
+        let rng = Rng(Cell::new(0));
+
+        rng.seed(seed);
+        rng
+    }
+}
+
 impl Rng {
     /// Generates a random `u32`.
     #[inline]


### PR DESCRIPTION
Useful for "splitting" the RNG when passing it down to sub-components/functions.

Note that this internally mutates the Rng to create a clone.

Closes #3 