### PR TITLE
Add wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["simple", "fast", "rand", "random", "pcg"]
 categories = ["algorithms"]
 readme = "README.md"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = "0.1"
+
 [dev-dependencies]
 rand = "0.7.3"
 rand_pcg = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,11 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::ops::{Bound, RangeBounds};
 use std::thread;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 
 /// A random number generator.
 #[derive(Debug)]


### PR DESCRIPTION
Currently this library (and `async-executor`) crashes on wasm due to missing `std::time`. This replaces it with cross-platform library `instant`.

Note that `instant` library could be used by default on all targets, but I added it for `wasm32` only as it cuts dependency count on native targets.